### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       logger.level: info
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: SuperSecretPassword_123
       http.max_content_length: 500mb
-      OPENSEARCH_JAVA_OPTS: "-Xms16g -Xmx16g"
+      OPENSEARCH_JAVA_OPTS: "-Xms1g -Xmx4g"
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Reduce allocated memory as machines with less than 16 GB won't start the docker container