### PR TITLE
change query set and search configuration identifier to be ID

### DIFF
--- a/curl_script/create_experiment.sh
+++ b/curl_script/create_experiment.sh
@@ -2,7 +2,7 @@ curl -s -X PUT "localhost:9200/_plugins/search_relevance/experiments" \
 -H "Content-type: application/json" \
 -d'{
    	"index": "sample_index",
-   	"querySetId": "test01",
-   	"searchConfigurationList": ["baseline", "multi_match"],
+   	"querySetId": "{query_set_id}",
+   	"searchConfigurationList": ["{search_configuration_id01}", "{search_configuration_id02}"],
    	"k": 10
    }' | jq

--- a/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
@@ -65,7 +65,7 @@ public class QuerySetDao {
         }
         try {
             searchRelevanceIndicesManager.putDoc(
-                querySet.name(),
+                querySet.id(),
                 querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
                 QUERY_SET,
                 listener
@@ -156,6 +156,7 @@ public class QuerySetDao {
         Map<String, Object> sourceMap = hit.getSourceAsMap();
 
         return QuerySet.Builder.builder()
+            .name((String) sourceMap.get(QuerySet.ID))
             .name((String) sourceMap.get(QuerySet.NAME))
             .description((String) sourceMap.get(QuerySet.DESCRIPTION))
             .timestamp((String) sourceMap.get(QuerySet.TIME_STAMP))

--- a/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
@@ -62,7 +62,7 @@ public class SearchConfigurationDao {
         }
         try {
             searchRelevanceIndicesManager.putDoc(
-                searchConfiguration.name(),
+                searchConfiguration.id(),
                 searchConfiguration.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
                 SEARCH_CONFIGURATION,
                 listener
@@ -169,6 +169,7 @@ public class SearchConfigurationDao {
     private SearchConfiguration convertToSearchConfiguration(SearchResponse response) {
         Map<String, Object> source = response.getHits().getHits()[0].getSourceAsMap();
         return new SearchConfiguration(
+            (String) source.get(SearchConfiguration.ID),
             (String) source.get(SearchConfiguration.NAME),
             (String) source.get(SearchConfiguration.TIME_STAMP),
             (String) source.get(SearchConfiguration.QUERY_BODY),

--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
@@ -19,6 +19,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
  */
 public class QuerySet implements ToXContentObject {
 
+    public static final String ID = "id";
     public static final String NAME = "name";
     public static final String DESCRIPTION = "description";
     public static final String TIME_STAMP = "timestamp";
@@ -28,13 +29,15 @@ public class QuerySet implements ToXContentObject {
     /**
      * Identifier of the system index
      */
+    private final String id;
     private final String name;
     private final String description;
     private final String sampling;
     private final String timestamp;
     private final Map<String, Integer> querySetQueries;
 
-    public QuerySet(String name, String description, String timestamp, String sampling, Map<String, Integer> querySetQueries) {
+    public QuerySet(String id, String name, String description, String timestamp, String sampling, Map<String, Integer> querySetQueries) {
+        this.id = id;
         this.description = description;
         this.name = name;
         this.sampling = sampling;
@@ -45,6 +48,7 @@ public class QuerySet implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(ID, this.id);
         xContentBuilder.field(NAME, this.name == null ? "" : this.name.trim());
         xContentBuilder.field(DESCRIPTION, this.description == null ? "" : this.description.trim());
         xContentBuilder.field(SAMPLING, this.sampling == null ? "" : this.sampling.trim());
@@ -59,6 +63,7 @@ public class QuerySet implements ToXContentObject {
     }
 
     public static class Builder {
+        private String id;
         private String name = "";
         private String description = "";
         private String sampling = "";
@@ -68,11 +73,17 @@ public class QuerySet implements ToXContentObject {
         private Builder() {}
 
         private Builder(QuerySet t) {
+            this.id = t.id;
             this.name = t.name;
             this.description = t.description;
             this.sampling = t.sampling;
             this.timestamp = t.timestamp;
             this.querySetQueries = t.querySetQueries;
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
         }
 
         public Builder name(String name) {
@@ -101,7 +112,7 @@ public class QuerySet implements ToXContentObject {
         }
 
         public QuerySet build() {
-            return new QuerySet(this.name, this.description, this.sampling, this.timestamp, this.querySetQueries);
+            return new QuerySet(this.id, this.name, this.description, this.sampling, this.timestamp, this.querySetQueries);
         }
 
         public static Builder builder() {
@@ -111,6 +122,10 @@ public class QuerySet implements ToXContentObject {
         public static Builder builder(QuerySet t) {
             return new Builder(t);
         }
+    }
+
+    public String id() {
+        return id;
     }
 
     public String name() {

--- a/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
@@ -16,6 +16,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
  * SearchConfiguration is a system index object that represents all search related params.
  */
 public class SearchConfiguration implements ToXContentObject {
+    public static final String ID = "id";
     public static final String NAME = "name";
     public static final String TIME_STAMP = "timestamp";
     public static final String QUERY_BODY = "queryBody";
@@ -24,12 +25,14 @@ public class SearchConfiguration implements ToXContentObject {
     /**
      * Identifier of the system index
      */
+    private final String id;
     private final String name;
     private final String timestamp;
     private final String queryBody;
     private final String searchPipeline;
 
-    public SearchConfiguration(String name, String timestamp, String queryBody, String searchPipeline) {
+    public SearchConfiguration(String id, String name, String timestamp, String queryBody, String searchPipeline) {
+        this.id = id;
         this.name = name;
         this.timestamp = timestamp;
         this.queryBody = queryBody;
@@ -39,11 +42,16 @@ public class SearchConfiguration implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(ID, this.id);
         xContentBuilder.field(NAME, this.name.trim());
         xContentBuilder.field(TIME_STAMP, this.timestamp.trim());
         xContentBuilder.field(QUERY_BODY, this.queryBody.trim());
         xContentBuilder.field(SEARCH_PIPELINE, this.searchPipeline == null ? "" : this.searchPipeline.trim());
         return xContentBuilder.endObject();
+    }
+
+    public String id() {
+        return id;
     }
 
     public String name() {

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -46,7 +46,6 @@ import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
 import org.opensearch.searchrelevance.metrics.MetricsHelper;
-import org.opensearch.searchrelevance.rest.PutCreateSearchConfigurationAction;
 import org.opensearch.searchrelevance.rest.RestCreateQuerySetAction;
 import org.opensearch.searchrelevance.rest.RestDeleteExperimentAction;
 import org.opensearch.searchrelevance.rest.RestDeleteJudgmentAction;
@@ -59,6 +58,7 @@ import org.opensearch.searchrelevance.rest.RestGetSearchConfigurationAction;
 import org.opensearch.searchrelevance.rest.RestPutExperimentAction;
 import org.opensearch.searchrelevance.rest.RestPutJudgmentAction;
 import org.opensearch.searchrelevance.rest.RestPutQuerySetAction;
+import org.opensearch.searchrelevance.rest.RestPutSearchConfigurationAction;
 import org.opensearch.searchrelevance.transport.experiment.DeleteExperimentAction;
 import org.opensearch.searchrelevance.transport.experiment.DeleteExperimentTransportAction;
 import org.opensearch.searchrelevance.transport.experiment.GetExperimentAction;
@@ -71,12 +71,12 @@ import org.opensearch.searchrelevance.transport.judgment.GetJudgmentAction;
 import org.opensearch.searchrelevance.transport.judgment.GetJudgmentTransportAction;
 import org.opensearch.searchrelevance.transport.judgment.PutJudgmentAction;
 import org.opensearch.searchrelevance.transport.judgment.PutJudgmentTransportAction;
-import org.opensearch.searchrelevance.transport.queryset.CreateQuerySetAction;
-import org.opensearch.searchrelevance.transport.queryset.CreateQuerySetTransportAction;
 import org.opensearch.searchrelevance.transport.queryset.DeleteQuerySetAction;
 import org.opensearch.searchrelevance.transport.queryset.DeleteQuerySetTransportAction;
 import org.opensearch.searchrelevance.transport.queryset.GetQuerySetAction;
 import org.opensearch.searchrelevance.transport.queryset.GetQuerySetTransportAction;
+import org.opensearch.searchrelevance.transport.queryset.PostQuerySetAction;
+import org.opensearch.searchrelevance.transport.queryset.PostQuerySetTransportAction;
 import org.opensearch.searchrelevance.transport.queryset.PutQuerySetAction;
 import org.opensearch.searchrelevance.transport.queryset.PutQuerySetTransportAction;
 import org.opensearch.searchrelevance.transport.searchConfiguration.DeleteSearchConfigurationAction;
@@ -154,7 +154,7 @@ public class SearchRelevancePlugin extends Plugin implements IngestPlugin, Actio
             new RestPutJudgmentAction(),
             new RestDeleteJudgmentAction(),
             new RestGetJudgmentAction(),
-            new PutCreateSearchConfigurationAction(),
+            new RestPutSearchConfigurationAction(),
             new RestDeleteSearchConfigurationAction(),
             new RestGetSearchConfigurationAction(),
             new RestPutExperimentAction(),
@@ -166,7 +166,7 @@ public class SearchRelevancePlugin extends Plugin implements IngestPlugin, Actio
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return List.of(
-            new ActionHandler<>(CreateQuerySetAction.INSTANCE, CreateQuerySetTransportAction.class),
+            new ActionHandler<>(PostQuerySetAction.INSTANCE, PostQuerySetTransportAction.class),
             new ActionHandler<>(PutQuerySetAction.INSTANCE, PutQuerySetTransportAction.class),
             new ActionHandler<>(DeleteQuerySetAction.INSTANCE, DeleteQuerySetTransportAction.class),
             new ActionHandler<>(GetQuerySetAction.INSTANCE, GetQuerySetTransportAction.class),

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetAction.java
@@ -25,8 +25,8 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
-import org.opensearch.searchrelevance.transport.queryset.CreateQuerySetAction;
-import org.opensearch.searchrelevance.transport.queryset.CreateQuerySetRequest;
+import org.opensearch.searchrelevance.transport.queryset.PostQuerySetAction;
+import org.opensearch.searchrelevance.transport.queryset.PostQuerySetRequest;
 import org.opensearch.transport.client.node.NodeClient;
 
 /**
@@ -57,9 +57,9 @@ public class RestCreateQuerySetAction extends BaseRestHandler {
         String sampling = (String) source.getOrDefault("sampling", "pptss");
         int querySetSize = (int) source.getOrDefault("querySetSize", 10);
 
-        CreateQuerySetRequest createRequest = new CreateQuerySetRequest(name, description, sampling, querySetSize);
+        PostQuerySetRequest createRequest = new PostQuerySetRequest(name, description, sampling, querySetSize);
 
-        return channel -> client.execute(CreateQuerySetAction.INSTANCE, createRequest, new ActionListener<IndexResponse>() {
+        return channel -> client.execute(PostQuerySetAction.INSTANCE, createRequest, new ActionListener<IndexResponse>() {
             @Override
             public void onResponse(IndexResponse response) {
                 try {

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
@@ -32,8 +32,8 @@ import org.opensearch.transport.client.node.NodeClient;
 /**
  * Rest Action to facilitate requests to create a search configuration.
  */
-public class PutCreateSearchConfigurationAction extends BaseRestHandler {
-    private static final Logger LOGGER = LogManager.getLogger(PutCreateSearchConfigurationAction.class);
+public class RestPutSearchConfigurationAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(RestPutSearchConfigurationAction.class);
     private static final String PUT_SEARCH_CONFIGURATION_ACTION = "put_search_configuration_action";
 
     @Override

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetAction.java
@@ -15,14 +15,14 @@ import org.opensearch.action.index.IndexResponse;
 /**
  * External Action for public facing RestCreateQuerySetAction
  */
-public class CreateQuerySetAction extends ActionType<IndexResponse> {
+public class PostQuerySetAction extends ActionType<IndexResponse> {
     /** The name of this action */
     public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "queryset/create";
 
     /** An instance of this action */
-    public static final CreateQuerySetAction INSTANCE = new CreateQuerySetAction();
+    public static final PostQuerySetAction INSTANCE = new PostQuerySetAction();
 
-    private CreateQuerySetAction() {
+    private PostQuerySetAction() {
         super(NAME, IndexResponse::new);
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetRequest.java
@@ -19,20 +19,20 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 /**
  * Create Request supports sampling from ubi queries.
  */
-public class CreateQuerySetRequest extends ActionRequest {
+public class PostQuerySetRequest extends ActionRequest {
     private String name;
     private String description;
     private String sampling;
     private int querySetSize;
 
-    public CreateQuerySetRequest(String name, String description, String sampling, int querySetSize) {
+    public PostQuerySetRequest(String name, String description, String sampling, int querySetSize) {
         this.name = Objects.requireNonNull(name, "name cannot be null.");
         this.description = description;
         this.sampling = Objects.requireNonNull(sampling, "sampling cannot be null.");
         this.querySetSize = Objects.requireNonNull(querySetSize, "querySetSize cannot be null.");
     }
 
-    public CreateQuerySetRequest(StreamInput in) throws IOException {
+    public PostQuerySetRequest(StreamInput in) throws IOException {
         super(in);
         this.name = in.readString();
         this.description = in.readString();

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
@@ -10,6 +10,7 @@ package org.opensearch.searchrelevance.transport.queryset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.opensearch.action.StepListener;
 import org.opensearch.action.index.IndexResponse;
@@ -46,9 +47,11 @@ public class PutQuerySetTransportAction extends HandledTransportAction<PutQueryS
             listener.onFailure(new IllegalArgumentException("Request cannot be null"));
             return;
         }
+        String id = UUID.randomUUID().toString();
+        String timestamp = TimeUtils.getTimestamp();
+
         String name = request.getName();
         String description = request.getDescription();
-        String timestamp = TimeUtils.getTimestamp();
 
         // Given sampling type by default "manual" to support manually uploaded querySetQueries.
         String sampling = request.getSampling();
@@ -61,7 +64,7 @@ public class PutQuerySetTransportAction extends HandledTransportAction<PutQueryS
         StepListener<Void> createIndexStep = new StepListener<>();
         querySetDao.createIndexIfAbsent(createIndexStep);
         createIndexStep.whenComplete(v -> {
-            QuerySet querySet = new QuerySet(name, description, timestamp, sampling, querySetQueries);
+            QuerySet querySet = new QuerySet(id, name, description, timestamp, sampling, querySetQueries);
             querySetDao.putQuerySet(querySet, listener);
         }, listener::onFailure);
     }

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationAction.java
@@ -13,7 +13,7 @@ import org.opensearch.action.ActionType;
 import org.opensearch.action.index.IndexResponse;
 
 /**
- * External Action for public facing PutCreateSearchConfigurationAction
+ * External Action for public facing RestPutSearchConfigurationAction
  */
 public class PutSearchConfigurationAction extends ActionType<IndexResponse> {
     /** The name of this action */

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
@@ -7,6 +7,8 @@
  */
 package org.opensearch.searchrelevance.transport.searchConfiguration;
 
+import java.util.UUID;
+
 import org.opensearch.action.StepListener;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -43,8 +45,10 @@ public class PutSearchConfigurationTransportAction extends HandledTransportActio
             listener.onFailure(new IllegalArgumentException("Request cannot be null"));
             return;
         }
-        String name = request.getName();
+        String id = UUID.randomUUID().toString();
         String timestamp = TimeUtils.getTimestamp();
+
+        String name = request.getName();
         if (name == null || name.trim().isEmpty()) {
             listener.onFailure(new IllegalArgumentException("Name cannot be null or empty. Request: " + request));
             return;
@@ -55,7 +59,7 @@ public class PutSearchConfigurationTransportAction extends HandledTransportActio
         StepListener<Void> createIndexStep = new StepListener<>();
         searchConfigurationDao.createIndexIfAbsent(createIndexStep);
         createIndexStep.whenComplete(v -> {
-            SearchConfiguration searchConfiguration = new SearchConfiguration(name, timestamp, queryBody, searchPipeline);
+            SearchConfiguration searchConfiguration = new SearchConfiguration(id, name, timestamp, queryBody, searchPipeline);
             searchConfigurationDao.putSearchConfiguration(searchConfiguration, listener);
         }, listener::onFailure);
     }

--- a/src/test/java/org/opensearch/searchrelevance/action/CreateQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/CreateQuerySetActionTests.java
@@ -11,17 +11,17 @@ import java.io.IOException;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.searchrelevance.transport.queryset.CreateQuerySetRequest;
+import org.opensearch.searchrelevance.transport.queryset.PostQuerySetRequest;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class CreateQuerySetActionTests extends OpenSearchTestCase {
 
     public void testStreams() throws IOException {
-        CreateQuerySetRequest request = new CreateQuerySetRequest("test_name", "test_description", "random", 10);
+        PostQuerySetRequest request = new PostQuerySetRequest("test_name", "test_description", "random", 10);
         BytesStreamOutput output = new BytesStreamOutput();
         request.writeTo(output);
         StreamInput in = StreamInput.wrap(output.bytes().toBytesRef().bytes);
-        CreateQuerySetRequest serialized = new CreateQuerySetRequest(in);
+        PostQuerySetRequest serialized = new PostQuerySetRequest(in);
         assertEquals("test_name", serialized.getName());
         assertEquals("test_description", serialized.getDescription());
         assertEquals("random", serialized.getSampling());
@@ -29,7 +29,7 @@ public class CreateQuerySetActionTests extends OpenSearchTestCase {
     }
 
     public void testRequestValidation() {
-        CreateQuerySetRequest request = new CreateQuerySetRequest("test_name", "test_description", "random", 10);
+        PostQuerySetRequest request = new PostQuerySetRequest("test_name", "test_description", "random", 10);
         assertNull(request.validate());
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -14,9 +14,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.IngestPlugin;
-import org.opensearch.searchrelevance.transport.queryset.CreateQuerySetAction;
 import org.opensearch.searchrelevance.transport.queryset.DeleteQuerySetAction;
 import org.opensearch.searchrelevance.transport.queryset.GetQuerySetAction;
+import org.opensearch.searchrelevance.transport.queryset.PostQuerySetAction;
 import org.opensearch.searchrelevance.transport.queryset.PutQuerySetAction;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -35,7 +35,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
     public void testQuerySetTransportIsAdded() {
         SearchRelevancePlugin plugin = new SearchRelevancePlugin();
         final List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = plugin.getActions();
-        assertEquals(1, actions.stream().filter(actionHandler -> actionHandler.getAction() instanceof CreateQuerySetAction).count());
+        assertEquals(1, actions.stream().filter(actionHandler -> actionHandler.getAction() instanceof PostQuerySetAction).count());
         assertEquals(1, actions.stream().filter(actionHandler -> actionHandler.getAction() instanceof PutQuerySetAction).count());
         assertEquals(1, actions.stream().filter(actionHandler -> actionHandler.getAction() instanceof GetQuerySetAction).count());
         assertEquals(1, actions.stream().filter(actionHandler -> actionHandler.getAction() instanceof DeleteQuerySetAction).count());


### PR DESCRIPTION
**Change**
- query set and search configuration use identifier as UUID instead of name.

**Resolve**
- issue - https://github.com/o19s/search-relevance/issues/66

**Test**
- able to create experiment, with UUID that returned when creating query set id or search configuration id
```
PUT localhost:9200/_plugins/search_relevance/experiments
{
	"index": "sample_index",
	"querySetId": "bde12f0b-c9bb-4ae8-a657-c55fb315512c",
	"searchConfigurationList": ["9434d5fe-0440-41ce-b9c4-fe23a585a73d", "8d55fefd-12c8-4ab7-b2d4-5342a30fcc44"],
	"k": 10
}
```