### PR TITLE
change SearchRelevanceException as extends from OpenSearchException

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/calculator/PairComparison.java
+++ b/src/main/java/org/opensearch/searchrelevance/calculator/PairComparison.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+
 /**
  * Calculators used for pairwise comparison.
  */
@@ -49,7 +52,7 @@ public class PairComparison {
      */
     public static double calculateRBOSimilarity(List<String> listA, List<String> listB, double p) {
         if (p <= 0 || p >= 1) {
-            throw new IllegalArgumentException("p must be between 0 and 1");
+            throw new SearchRelevanceException("p must be between 0 and 1", RestStatus.INTERNAL_SERVER_ERROR);
         }
 
         int maxDepth = Math.max(listA.size(), listB.size());

--- a/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
@@ -49,7 +49,7 @@ public class ExperimentDao {
      */
     public void putExperiment(final Experiment experiment, final ActionListener listener) {
         if (experiment == null) {
-            listener.onFailure(new IllegalArgumentException("Experiment cannot be null"));
+            listener.onFailure(new SearchRelevanceException("Experiment cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         try {
@@ -80,7 +80,7 @@ public class ExperimentDao {
      */
     public SearchResponse getExperiment(String experimentId, ActionListener<SearchResponse> listener) {
         if (experimentId == null || experimentId.isEmpty()) {
-            listener.onFailure(new IllegalArgumentException("experimentId must not be null or empty"));
+            listener.onFailure(new SearchRelevanceException("experimentId must not be null or empty", RestStatus.BAD_REQUEST));
             return null;
         }
         return searchRelevanceIndicesManager.getDocByDocId(experimentId, EXPERIMENT, listener);

--- a/src/main/java/org/opensearch/searchrelevance/dao/JudgmentDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/JudgmentDao.java
@@ -51,7 +51,7 @@ public class JudgmentDao {
      */
     public void putJudgement(final Judgment judgment, final ActionListener listener) {
         if (judgment == null) {
-            listener.onFailure(new IllegalArgumentException("Judgment cannot be null"));
+            listener.onFailure(new SearchRelevanceException("Judgment cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         try {
@@ -82,7 +82,7 @@ public class JudgmentDao {
      */
     public SearchResponse getJudgment(String judgmentId, ActionListener<SearchResponse> listener) {
         if (judgmentId == null || judgmentId.isEmpty()) {
-            listener.onFailure(new IllegalArgumentException("judgmentId must not be null or empty"));
+            listener.onFailure(new SearchRelevanceException("judgmentId must not be null or empty", RestStatus.BAD_REQUEST));
             return null;
         }
         return searchRelevanceIndicesManager.getDocByDocId(judgmentId, JUDGMENT, listener);

--- a/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
@@ -60,7 +60,7 @@ public class QuerySetDao {
      */
     public void putQuerySet(final QuerySet querySet, final ActionListener listener) {
         if (querySet == null) {
-            listener.onFailure(new IllegalArgumentException("QuerySet cannot be null"));
+            listener.onFailure(new SearchRelevanceException("QuerySet cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         try {
@@ -91,7 +91,7 @@ public class QuerySetDao {
      */
     public SearchResponse getQuerySet(String querySetId, ActionListener<SearchResponse> listener) {
         if (querySetId == null || querySetId.isEmpty()) {
-            listener.onFailure(new IllegalArgumentException("querySetId must not be null or empty"));
+            listener.onFailure(new SearchRelevanceException("querySetId must not be null or empty", RestStatus.BAD_REQUEST));
             return null;
         }
         return searchRelevanceIndicesManager.getDocByDocId(querySetId, QUERY_SET, listener);

--- a/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
@@ -57,7 +57,7 @@ public class SearchConfigurationDao {
      */
     public void putSearchConfiguration(final SearchConfiguration searchConfiguration, final ActionListener listener) {
         if (searchConfiguration == null) {
-            listener.onFailure(new IllegalArgumentException("SearchConfiguration cannot be null"));
+            listener.onFailure(new SearchRelevanceException("SearchConfiguration cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         try {
@@ -88,7 +88,7 @@ public class SearchConfigurationDao {
      */
     public SearchResponse getSearchConfiguration(String searchConfigurationId, ActionListener<SearchResponse> listener) {
         if (searchConfigurationId == null || searchConfigurationId.isEmpty()) {
-            listener.onFailure(new IllegalArgumentException("querySetId must not be null or empty"));
+            listener.onFailure(new SearchRelevanceException("querySetId must not be null or empty", RestStatus.BAD_REQUEST));
             return null;
         }
         return searchRelevanceIndicesManager.getDocByDocId(searchConfigurationId, SEARCH_CONFIGURATION, listener);

--- a/src/main/java/org/opensearch/searchrelevance/exception/SearchRelevanceException.java
+++ b/src/main/java/org/opensearch/searchrelevance/exception/SearchRelevanceException.java
@@ -7,12 +7,13 @@
  */
 package org.opensearch.searchrelevance.exception;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.core.rest.RestStatus;
 
 /**
  * Representations of Search Relevance Exceptions
  */
-public class SearchRelevanceException extends RuntimeException {
+public class SearchRelevanceException extends OpenSearchException {
     private final RestStatus restStatus;
 
     /**

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
@@ -20,6 +20,9 @@ import static org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManag
 import java.io.IOException;
 import java.util.Objects;
 
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+
 public enum SearchRelevanceIndices {
     /**
      * Query Set Index
@@ -53,7 +56,7 @@ public enum SearchRelevanceIndices {
         try {
             return getIndexMappings(mappingPath);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to load mapping under path: " + mappingPath, e);
+            throw new SearchRelevanceException("Failed to load mapping under path: " + mappingPath, e, RestStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -225,7 +225,7 @@ public class SearchRelevanceIndicesManager {
      */
     public static String getIndexMappings(final String mapping) throws IOException {
         if (mapping == null || mapping.trim().isEmpty()) {
-            throw new IllegalArgumentException("Mapping path cannot be null or empty");
+            throw new SearchRelevanceException("Mapping path cannot be null or empty", RestStatus.INTERNAL_SERVER_ERROR);
         }
 
         final String path = mapping.startsWith("/") ? mapping : "/" + mapping;

--- a/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
@@ -235,7 +235,7 @@ public class MetricsHelper {
             double jaccardSimilarity = calculateJaccardSimilarity(docIdListA, docIdListB);
             metrics.put(JACCARD_SIMILARITY_FIELD_NAME, jaccardSimilarity);
         } catch (Exception ex) {
-            throw new IllegalArgumentException("failed to calculate jaccard", ex);
+            throw new SearchRelevanceException("failed to calculate jaccard", ex, RestStatus.INTERNAL_SERVER_ERROR);
         }
 
         try {
@@ -244,14 +244,14 @@ public class MetricsHelper {
             metrics.put(RBO_50_SIMILARITY_FIELD_NAME, rboSimilarity50);
             metrics.put(RBO_90_SIMILARITY_FIELD_NAME, rboSimilarity90);
         } catch (Exception ex) {
-            throw new IllegalArgumentException("failed to calculate rbo", ex);
+            throw new SearchRelevanceException("failed to calculate rbo", ex, RestStatus.INTERNAL_SERVER_ERROR);
         }
 
         try {
             double frequencyWeightedSimilarity = calculateFrequencyWeightedSimilarity(docIdListA, docIdListB);
             metrics.put(FREQUENCY_WEIGHTED_SIMILARITY_FIELD_NAME, frequencyWeightedSimilarity);
         } catch (Exception ex) {
-            throw new IllegalArgumentException("failed to calculate frequencyWeighted", ex);
+            throw new SearchRelevanceException("failed to calculate frequencyWeighted", ex, RestStatus.INTERNAL_SERVER_ERROR);
         }
         return metrics;
     }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteExperimentAction.java
@@ -26,6 +26,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.searchrelevance.transport.experiment.DeleteExperimentAction;
 import org.opensearch.transport.client.node.NodeClient;
@@ -48,7 +49,7 @@ public class RestDeleteExperimentAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         final String experimentId = request.param(DOCUMENT_ID);
         if (experimentId == null) {
-            throw new IllegalArgumentException("id cannot be null");
+            throw new SearchRelevanceException("id cannot be null", RestStatus.BAD_REQUEST);
         }
         OpenSearchDocRequest deleteRequest = new OpenSearchDocRequest(experimentId);
         return channel -> client.execute(DeleteExperimentAction.INSTANCE, deleteRequest, new ActionListener<DeleteResponse>() {

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteJudgmentAction.java
@@ -26,6 +26,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.searchrelevance.transport.judgment.DeleteJudgmentAction;
 import org.opensearch.transport.client.node.NodeClient;
@@ -51,7 +52,7 @@ public class RestDeleteJudgmentAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         final String judgmentId = request.param(DOCUMENT_ID);
         if (judgmentId == null) {
-            throw new IllegalArgumentException("id cannot be null");
+            throw new SearchRelevanceException("id cannot be null", RestStatus.BAD_REQUEST);
         }
         OpenSearchDocRequest deleteRequest = new OpenSearchDocRequest(judgmentId);
         return channel -> client.execute(DeleteJudgmentAction.INSTANCE, deleteRequest, new ActionListener<DeleteResponse>() {

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetAction.java
@@ -26,6 +26,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.searchrelevance.transport.queryset.DeleteQuerySetAction;
 import org.opensearch.transport.client.node.NodeClient;
@@ -51,7 +52,7 @@ public class RestDeleteQuerySetAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         final String querySetId = request.param(DOCUMENT_ID);
         if (querySetId == null) {
-            throw new IllegalArgumentException("id cannot be null");
+            throw new SearchRelevanceException("id cannot be null", RestStatus.BAD_REQUEST);
         }
         OpenSearchDocRequest deleteRequest = new OpenSearchDocRequest(querySetId);
         return channel -> client.execute(DeleteQuerySetAction.INSTANCE, deleteRequest, new ActionListener<DeleteResponse>() {

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationAction.java
@@ -26,6 +26,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.searchrelevance.transport.searchConfiguration.DeleteSearchConfigurationAction;
 import org.opensearch.transport.client.node.NodeClient;
@@ -51,7 +52,7 @@ public class RestDeleteSearchConfigurationAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         final String searchConfigurationId = request.param(DOCUMENT_ID);
         if (searchConfigurationId == null) {
-            throw new IllegalArgumentException("id cannot be null");
+            throw new SearchRelevanceException("id cannot be null", RestStatus.BAD_REQUEST);
         }
         OpenSearchDocRequest deleteRequest = new OpenSearchDocRequest(searchConfigurationId);
         return channel -> client.execute(DeleteSearchConfigurationAction.INSTANCE, deleteRequest, new ActionListener<DeleteResponse>() {

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportAction.java
@@ -16,7 +16,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.ExperimentDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -48,7 +50,7 @@ public class DeleteExperimentTransportAction extends HandledTransportAction<Open
         try {
             String experimentId = request.getId();
             if (experimentId == null || experimentId.trim().isEmpty()) {
-                listener.onFailure(new IllegalArgumentException("Experiment ID cannot be null or empty"));
+                listener.onFailure(new SearchRelevanceException("Experiment ID cannot be null or empty", RestStatus.BAD_REQUEST));
                 return;
             }
             experimentDao.deleteExperiment(experimentId, listener);

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
@@ -22,9 +22,11 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.ExperimentDao;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.metrics.MetricsHelper;
 import org.opensearch.searchrelevance.model.Experiment;
 import org.opensearch.searchrelevance.utils.TimeUtils;
@@ -60,7 +62,7 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
     @Override
     protected void doExecute(Task task, PutExperimentRequest request, ActionListener<IndexResponse> listener) {
         if (request == null) {
-            listener.onFailure(new IllegalArgumentException("Request cannot be null"));
+            listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         String id = UUID.randomUUID().toString();

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
@@ -16,7 +16,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -48,7 +50,7 @@ public class DeleteJudgmentTransportAction extends HandledTransportAction<OpenSe
         try {
             String judgmentId = request.getId();
             if (judgmentId == null || judgmentId.trim().isEmpty()) {
-                listener.onFailure(new IllegalArgumentException("judgmentId cannot be null or empty"));
+                listener.onFailure(new SearchRelevanceException("judgmentId cannot be null or empty", RestStatus.BAD_REQUEST));
                 return;
             }
             judgmentDao.deleteJudgment(judgmentId, listener);

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
@@ -16,7 +16,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.Judgment;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
@@ -41,7 +43,7 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
     @Override
     protected void doExecute(Task task, PutJudgmentRequest request, ActionListener<IndexResponse> listener) {
         if (request == null) {
-            listener.onFailure(new IllegalArgumentException("Request cannot be null"));
+            listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         String id = UUID.randomUUID().toString();

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportAction.java
@@ -16,7 +16,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -48,7 +50,7 @@ public class DeleteQuerySetTransportAction extends HandledTransportAction<OpenSe
         try {
             String querySetId = request.getId();
             if (querySetId == null || querySetId.trim().isEmpty()) {
-                listener.onFailure(new IllegalArgumentException("Query set ID cannot be null or empty"));
+                listener.onFailure(new SearchRelevanceException("Query set ID cannot be null or empty", RestStatus.BAD_REQUEST));
                 return;
             }
             querySetDao.deleteQuerySet(querySetId, listener);

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
@@ -19,7 +19,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.ubi.QuerySampler;
 import org.opensearch.searchrelevance.utils.TimeUtils;
@@ -49,7 +51,7 @@ public class PostQuerySetTransportAction extends HandledTransportAction<PostQuer
     @Override
     protected void doExecute(Task task, PostQuerySetRequest request, ActionListener<IndexResponse> listener) {
         if (request == null) {
-            listener.onFailure(new IllegalArgumentException("Request cannot be null"));
+            listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         String id = UUID.randomUUID().toString();
@@ -66,11 +68,13 @@ public class PostQuerySetTransportAction extends HandledTransportAction<PostQuer
         try {
             querySetQueries = querySampler.sample().get();
         } catch (InterruptedException | ExecutionException e) {
-            listener.onFailure(new IllegalArgumentException("Failed to build querySetQueries. Request: " + request));
+            listener.onFailure(
+                new SearchRelevanceException("Failed to build querySetQueries. Request: " + request, RestStatus.BAD_REQUEST)
+            );
         }
 
         if (name == null || name.trim().isEmpty()) {
-            listener.onFailure(new IllegalArgumentException("Name cannot be null or empty. Request: " + request));
+            listener.onFailure(new SearchRelevanceException("Name cannot be null or empty. Request: " + request, RestStatus.BAD_REQUEST));
             return;
         }
 

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
@@ -19,7 +19,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
@@ -44,7 +46,7 @@ public class PutQuerySetTransportAction extends HandledTransportAction<PutQueryS
     @Override
     protected void doExecute(Task task, PutQuerySetRequest request, ActionListener<IndexResponse> listener) {
         if (request == null) {
-            listener.onFailure(new IllegalArgumentException("Request cannot be null"));
+            listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         String id = UUID.randomUUID().toString();
@@ -56,7 +58,9 @@ public class PutQuerySetTransportAction extends HandledTransportAction<PutQueryS
         // Given sampling type by default "manual" to support manually uploaded querySetQueries.
         String sampling = request.getSampling();
         if (!"manual".equals(sampling)) {
-            listener.onFailure(new IllegalArgumentException("Support sampling as manual only. sampling: " + sampling));
+            listener.onFailure(
+                new SearchRelevanceException("Support sampling as manual only. sampling: " + sampling, RestStatus.BAD_REQUEST)
+            );
         }
         String querySetQueriesStr = request.getQuerySetQueries();
         Map<String, Integer> querySetQueries = convertQuerySetQueriesMap(querySetQueriesStr);

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
@@ -16,7 +16,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.transport.OpenSearchDocRequest;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -48,7 +50,7 @@ public class DeleteSearchConfigurationTransportAction extends HandledTransportAc
         try {
             String searchConfigurationId = request.getId();
             if (searchConfigurationId == null || searchConfigurationId.trim().isEmpty()) {
-                listener.onFailure(new IllegalArgumentException("searchConfigurationId cannot be null or empty"));
+                listener.onFailure(new SearchRelevanceException("searchConfigurationId cannot be null or empty", RestStatus.BAD_REQUEST));
                 return;
             }
             searchConfigurationDao.deleteSearchConfiguration(searchConfigurationId, listener);

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
@@ -16,7 +16,9 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.SearchConfiguration;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
@@ -42,7 +44,7 @@ public class PutSearchConfigurationTransportAction extends HandledTransportActio
     @Override
     protected void doExecute(Task task, PutSearchConfigurationRequest request, ActionListener<IndexResponse> listener) {
         if (request == null) {
-            listener.onFailure(new IllegalArgumentException("Request cannot be null"));
+            listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
         String id = UUID.randomUUID().toString();
@@ -50,7 +52,7 @@ public class PutSearchConfigurationTransportAction extends HandledTransportActio
 
         String name = request.getName();
         if (name == null || name.trim().isEmpty()) {
-            listener.onFailure(new IllegalArgumentException("Name cannot be null or empty. Request: " + request));
+            listener.onFailure(new SearchRelevanceException("Name cannot be null or empty. Request: " + request, RestStatus.BAD_REQUEST));
             return;
         }
         String queryBody = request.getQueryBody();

--- a/src/main/java/org/opensearch/searchrelevance/ubi/QuerySampler.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/QuerySampler.java
@@ -12,6 +12,8 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.transport.client.Client;
 
 import reactor.util.annotation.NonNull;
@@ -41,7 +43,7 @@ public abstract class QuerySampler {
             case ProbabilityProportionalToSizeQuerySampler.NAME -> new ProbabilityProportionalToSizeQuerySampler(size, client);
             case RandomQuerySampler.NAME -> new RandomQuerySampler(size, client);
             case TopNQuerySampler.NAME -> new TopNQuerySampler(size, client);
-            default -> throw new IllegalArgumentException("Unknown sampler type: " + name);
+            default -> throw new SearchRelevanceException("Unknown sampler type: " + name, RestStatus.BAD_REQUEST);
         };
     }
 }


### PR DESCRIPTION
**Change**
This PR is aiming to change SearchRelevanceException to be an extends from OpenSearchException.
- It will throw RestStatus as BAD_REQUEST or INTERNAL_SERVER_ERRORs with error status code. 

**Resolve**
- issue: https://github.com/o19s/search-relevance/issues/64