### PR TITLE
fix sort field for query_sets and search_configs scripts

### DIFF
--- a/curl_script/list_query_set.sh
+++ b/curl_script/list_query_set.sh
@@ -2,7 +2,7 @@ curl -s -X GET "localhost:9200/_plugins/search_relevance/query_sets" \
 -H "Content-type: application/json" \
 -d'{
      "sort": {
-       "sampling": {
+       "timestamp": {
          "order": "desc"
        }
      },

--- a/curl_script/list_search_configuration.sh
+++ b/curl_script/list_search_configuration.sh
@@ -2,7 +2,7 @@ curl -s -X GET "http://localhost:9200/_plugins/search_relevance/search_configura
 -H "Content-type: application/json" \
 -d'{
      "sort": {
-       "sampling": {
+       "timestamp": {
          "order": "desc"
        }
      },


### PR DESCRIPTION
- fix the sort field name to `timestamp`
```
GET localhost:9200/_plugins/search_relevance/search_configurations
{
    "sort": {
     "timestamp": {
       "order": "desc"
     }
  },
     "size": 10
}
```