### PR TITLE
support queryText with referenceAnswer for queryset and llm judgment processor

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
@@ -88,7 +88,7 @@ public class MLAccessor {
             if (Objects.isNull(reference) || reference.isEmpty()) {
                 userContent = String.format(Locale.ROOT, INPUT_FORMAT_SEARCH, searchText, hitsJson);
             } else {
-                userContent = String.format(Locale.ROOT, INPUT_FORMAT_SEARCH_WITH_REFERENCE, searchText, hitsJson, reference);
+                userContent = String.format(Locale.ROOT, INPUT_FORMAT_SEARCH_WITH_REFERENCE, searchText, reference, hitsJson);
             }
             String messages = String.format(Locale.ROOT, PROMPT_JSON_MESSAGES_SHELL, PROMPT_SEARCH_RELEVANCE, escapeJson(userContent));
 

--- a/src/main/java/org/opensearch/searchrelevance/model/QueryWithReference.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QueryWithReference.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+
+public class QueryWithReference implements Writeable {
+    private final String queryText;
+    private final String referenceAnswer;
+
+    public final static String DELIMITER = "#";
+
+    public QueryWithReference(String queryText, String referenceAnswer) {
+        this.queryText = queryText;
+        this.referenceAnswer = referenceAnswer;
+    }
+
+    public QueryWithReference(StreamInput in) throws IOException {
+        this.queryText = in.readString();
+        this.referenceAnswer = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(queryText);
+        out.writeString(referenceAnswer);
+    }
+
+    public String getQueryText() {
+        return queryText;
+    }
+
+    public String getReferenceAnswer() {
+        return referenceAnswer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueryWithReference that = (QueryWithReference) o;
+        return Objects.equals(queryText, that.queryText) && Objects.equals(referenceAnswer, that.referenceAnswer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(queryText, referenceAnswer);
+    }
+
+    @Override
+    public String toString() {
+        return "QueryWithReference{" + "queryText='" + queryText + '\'' + ", referenceAnswer='" + referenceAnswer + '\'' + '}';
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetRequest.java
@@ -8,12 +8,14 @@
 package org.opensearch.searchrelevance.transport.queryset;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.searchrelevance.model.QueryWithReference;
 
 import reactor.util.annotation.NonNull;
 
@@ -24,9 +26,14 @@ public class PutQuerySetRequest extends ActionRequest {
     private final String name;
     private final String description;
     private final String sampling;
-    private final String querySetQueries;
+    private final List<QueryWithReference> querySetQueries;
 
-    public PutQuerySetRequest(@NonNull String name, String description, @NonNull String sampling, @NonNull String querySetQueries) {
+    public PutQuerySetRequest(
+        @NonNull String name,
+        String description,
+        @NonNull String sampling,
+        @NonNull List<QueryWithReference> querySetQueries
+    ) {
         this.name = name;
         this.description = description;
         this.sampling = sampling;
@@ -38,7 +45,7 @@ public class PutQuerySetRequest extends ActionRequest {
         this.name = in.readString();
         this.description = in.readOptionalString();
         this.sampling = in.readString();
-        this.querySetQueries = in.readString();
+        this.querySetQueries = in.readList(QueryWithReference::new);
     }
 
     @Override
@@ -47,7 +54,7 @@ public class PutQuerySetRequest extends ActionRequest {
         out.writeString(name);
         out.writeOptionalString(description);
         out.writeString(sampling);
-        out.writeString(querySetQueries);
+        out.writeList(querySetQueries);
     }
 
     public String getName() {
@@ -63,7 +70,7 @@ public class PutQuerySetRequest extends ActionRequest {
         return sampling;
     }
 
-    public String getQuerySetQueries() {
+    public List<QueryWithReference> getQuerySetQueries() {
         return querySetQueries;
     }
 

--- a/src/test/java/org/opensearch/searchrelevance/action/queryset/PutQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/queryset/PutQuerySetActionTests.java
@@ -8,16 +8,19 @@
 package org.opensearch.searchrelevance.action.queryset;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.searchrelevance.model.QueryWithReference;
 import org.opensearch.searchrelevance.transport.queryset.PutQuerySetRequest;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class PutQuerySetActionTests extends OpenSearchTestCase {
 
     public void testStreams() throws IOException {
-        PutQuerySetRequest request = new PutQuerySetRequest("test_name", "test_description", "manual", "apple, banana");
+        PutQuerySetRequest request = new PutQuerySetRequest("test_name", "test_description", "manual", getQuerySetQueries());
         BytesStreamOutput output = new BytesStreamOutput();
         request.writeTo(output);
         StreamInput in = StreamInput.wrap(output.bytes().toBytesRef().bytes);
@@ -25,11 +28,18 @@ public class PutQuerySetActionTests extends OpenSearchTestCase {
         assertEquals("test_name", serialized.getName());
         assertEquals("test_description", serialized.getDescription());
         assertEquals("manual", serialized.getSampling());
-        assertEquals("apple, banana", serialized.getQuerySetQueries());
+        assertEquals(getQuerySetQueries(), serialized.getQuerySetQueries());
     }
 
     public void testRequestValidation() {
-        PutQuerySetRequest request = new PutQuerySetRequest("test_name", "test_description", "manual", "apple, banana");
+        PutQuerySetRequest request = new PutQuerySetRequest("test_name", "test_description", "manual", getQuerySetQueries());
         assertNull(request.validate());
+    }
+
+    private List<QueryWithReference> getQuerySetQueries() {
+        List<QueryWithReference> querySetQueries = new ArrayList<>();
+        querySetQueries.add(new QueryWithReference("apple", ""));
+        querySetQueries.add(new QueryWithReference("banana", ""));
+        return querySetQueries;
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestExperimentActionIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestExperimentActionIT.java
@@ -10,12 +10,14 @@ package org.opensearch.searchrelevance.rest;
 import static org.opensearch.searchrelevance.rest.RestQuerySetActionIT.createQuerySetRequestBody;
 import static org.opensearch.searchrelevance.rest.RestSearchConfigurationActionIT.createSearchConfigurationRequestBody;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.model.QueryWithReference;
 import org.opensearch.searchrelevance.plugin.SearchRelevanceRestTestCase;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -101,5 +103,12 @@ public class RestExperimentActionIT extends SearchRelevanceRestTestCase {
         requestMap.put("size", 10);
         requestMap.put("type", "PAIRWISE_COMPARISON");
         return OBJECT_MAPPER.writeValueAsString(requestMap);
+    }
+
+    private List<QueryWithReference> getQuerySetQueries() {
+        List<QueryWithReference> querySetQueries = new ArrayList<>();
+        querySetQueries.add(new QueryWithReference("apple", ""));
+        querySetQueries.add(new QueryWithReference("banana", ""));
+        return querySetQueries;
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestQuerySetActionIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestQuerySetActionIT.java
@@ -7,12 +7,15 @@
  */
 package org.opensearch.searchrelevance.rest;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.model.QueryWithReference;
 import org.opensearch.searchrelevance.plugin.SearchRelevanceRestTestCase;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -71,7 +74,14 @@ public class RestQuerySetActionIT extends SearchRelevanceRestTestCase {
         requestMap.put("name", name);
         requestMap.put("description", description);
         requestMap.put("sampling", "manual");
-        requestMap.put("querySetQueries", "apple, banana");
+        requestMap.put("querySetQueries", getQuerySetQueries());
         return OBJECT_MAPPER.writeValueAsString(requestMap);
+    }
+
+    private static List<QueryWithReference> getQuerySetQueries() {
+        List<QueryWithReference> querySetQueries = new ArrayList<>();
+        querySetQueries.add(new QueryWithReference("apple", ""));
+        querySetQueries.add(new QueryWithReference("banana", ""));
+        return querySetQueries;
     }
 }


### PR DESCRIPTION
### Changes
- query set supports a file uploading from frontend instead of text box input
- query set supports queryText 
- query set supports queryText with referenceAnswer 
- LLM judgment processor supports make judgment with only queryText
- LLM judgment processor supports make judgment with queryText and corresponding referenceAnswer

```
{
				"_index": ".plugins-search-relevance-judgment",
				"_id": "f65465f4-619d-4fcd-bcf4-620b5b77ecfc",
				"_score": null,
				"_source": {
					"id": "f65465f4-619d-4fcd-bcf4-620b5b77ecfc",
					"timestamp": "2025-05-16T17:33:47.103Z",
					"name": "LLM Judgment with reference",
					"status": "COMPLETED",
					"type": "LLM_JUDGMENT",
					"metadata": {
						"size": 5,
						"modelId": "G7om2pYBDwub4UBLKhc8",
						"searchConfigurationList": [
							"380b2686-a2cd-40e5-b0c9-1d4d93fabbba"
						],
						"querySetId": "362901d8-8549-4a23-bc19-dfb59362ae4b"
					},
					"judgmentScores": {
						"test#test smoothie": [
							{
								"docId": "001",
								"score": "0.7"
							},
							{
								"docId": "002",
								"score": "0.4"
							},
							{
								"docId": "003",
								"score": "0.3"
							}
						],
						"banana#banana smoothie": [
							{
								"docId": "banana smoothie",
								"score": "0.6"
							}
						],
						"apple#apple smoothie": [
							{
								"docId": "apple smoothie",
								"score": "0.1"
							}
						]
					}
				},
				"sort": [
					1747416827103
				]
			}
```

### Resolve
- https://github.com/o19s/search-relevance/issues/98