### PR TITLE
Fixed spotless errors in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         hard: -1
       nofile:
         soft: 65536
-        hard: 65536        
+        hard: 65536
     ports:
       - 9200:9200
       - 9600:9600 # required for Performance Analyzer


### PR DESCRIPTION
Fixed error caused CI failures cause by spotless checks, example https://github.com/o19s/search-relevance/actions/runs/15145118171/job/42578822286?pr=111

```
Execution failed for task ':spotlessMiscCheck'.
> The following files had format violations:
      docker-compose.yml
          @@ -18,7 +18,7 @@
           ········hard:·-1
           ······nofile:
           ········soft:·65536
          -········hard:·65536········
          +········hard:·65536
           ····ports:
           ······-·9200:9200
           ······-·9600:9600·#·required·for·Performance·Analyzer
  Run 'gradlew.bat :spotlessApply' to fix these violations.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org./

BUILD FAILED in 3m 33s
Error:
```

